### PR TITLE
Make options consistent

### DIFF
--- a/Detectors/CPV/workflow/include/CPVWorkflow/RecoWorkflow.h
+++ b/Detectors/CPV/workflow/include/CPVWorkflow/RecoWorkflow.h
@@ -38,7 +38,6 @@ enum struct OutputType { Digits,
 framework::WorkflowSpec getWorkflow(bool disableRootInp,
                                     bool disableRootOut,
                                     bool propagateMC = true,
-                                    bool enableDigitsPrinter = false,
                                     std::string const& cfgInput = "digits",   //
                                     std::string const& cfgOutput = "clusters" //
 );

--- a/Detectors/CPV/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/CPV/workflow/src/RecoWorkflow.cxx
@@ -57,7 +57,6 @@ const std::unordered_map<std::string, OutputType> OutputMap{
 o2::framework::WorkflowSpec getWorkflow(bool disableRootInp,
                                         bool disableRootOut,
                                         bool propagateMC,
-                                        bool enableDigitsPrinter,
                                         std::string const& cfgInput,
                                         std::string const& cfgOutput)
 {
@@ -105,10 +104,6 @@ o2::framework::WorkflowSpec getWorkflow(bool disableRootInp,
     if (!disableRootInp) {
       specs.emplace_back(o2::cpv::getDigitsReaderSpec(propagateMC));
     }
-
-    // if (enableDigitsPrinter) {
-    //   specs.emplace_back(o2::cpv::reco_workflow::getDigitsPrinterSpec());
-    // }
 
     if (isEnabled(OutputType::Clusters)) {
       // add clusterizer

--- a/Detectors/CPV/workflow/src/cpv-reco-workflow.cxx
+++ b/Detectors/CPV/workflow/src/cpv-reco-workflow.cxx
@@ -17,6 +17,7 @@
 #include "Framework/ConfigParamSpec.h"
 #include "CPVWorkflow/RecoWorkflow.h"
 #include "Algorithm/RangeTokenizer.h"
+#include "CommonUtils/ConfigurableParam.h"
 
 #include <string>
 #include <stdexcept>
@@ -27,13 +28,12 @@
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::vector<o2::framework::ConfigParamSpec> options{
-    {"input-type", o2::framework::VariantType::String, "hits", {"hits, digits, raw, clusters"}},
-    {"output-type", o2::framework::VariantType::String, "digits", {"digits, clusters"}},
-    {"enable-digits-printer", o2::framework::VariantType::Bool, false, {"enable digits printer component"}},
+    {"input-type", o2::framework::VariantType::String, "digits", {"hits, digits, raw, clusters"}},
+    {"output-type", o2::framework::VariantType::String, "clusters", {"digits, clusters"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information"}},
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
-  };
+    {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   std::swap(workflowOptions, options);
 }
 
@@ -54,11 +54,13 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
   //
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
+
   return o2::cpv::reco_workflow::getWorkflow(cfgc.options().get<bool>("disable-root-input"),
                                              cfgc.options().get<bool>("disable-root-output"),
-                                             !cfgc.options().get<bool>("disable-mc"),           //
-                                             cfgc.options().get<bool>("enable-digits-printer"), //
-                                             cfgc.options().get<std::string>("input-type"),     //
-                                             cfgc.options().get<std::string>("output-type")     //
+                                             !cfgc.options().get<bool>("disable-mc"),       //
+                                             cfgc.options().get<std::string>("input-type"), //
+                                             cfgc.options().get<std::string>("output-type") //
   );
 }

--- a/Detectors/PHOS/workflow/include/PHOSWorkflow/RecoWorkflow.h
+++ b/Detectors/PHOS/workflow/include/PHOSWorkflow/RecoWorkflow.h
@@ -41,7 +41,6 @@ enum struct OutputType { Digits,
 framework::WorkflowSpec getWorkflow(bool disableRootInp,
                                     bool disableRootOut,
                                     bool propagateMC = true,
-                                    bool enableDigitsPrinter = false,
                                     std::string const& cfgInput = "hits",     //
                                     std::string const& cfgOutput = "clusters" //
 );

--- a/Detectors/PHOS/workflow/src/RecoWorkflow.cxx
+++ b/Detectors/PHOS/workflow/src/RecoWorkflow.cxx
@@ -24,7 +24,6 @@
 #include "PHOSWorkflow/RecoWorkflow.h"
 #include "PHOSWorkflow/CellConverterSpec.h"
 #include "PHOSWorkflow/ClusterizerSpec.h"
-#include "PHOSWorkflow/DigitsPrinterSpec.h"
 #include "PHOSWorkflow/ReaderSpec.h"
 #include "PHOSWorkflow/WriterSpec.h"
 #include "PHOSWorkflow/RawToCellConverterSpec.h"
@@ -56,7 +55,6 @@ const std::unordered_map<std::string, OutputType> OutputMap{
 o2::framework::WorkflowSpec getWorkflow(bool disableRootInp,
                                         bool disableRootOut,
                                         bool propagateMC,
-                                        bool enableDigitsPrinter,
                                         std::string const& cfgInput,
                                         std::string const& cfgOutput)
 {

--- a/Detectors/PHOS/workflow/src/phos-reco-workflow.cxx
+++ b/Detectors/PHOS/workflow/src/phos-reco-workflow.cxx
@@ -17,6 +17,7 @@
 #include "Framework/ConfigParamSpec.h"
 #include "PHOSWorkflow/RecoWorkflow.h"
 #include "Algorithm/RangeTokenizer.h"
+#include "CommonUtils/ConfigurableParam.h"
 
 #include <string>
 #include <stdexcept>
@@ -27,13 +28,12 @@
 void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 {
   std::vector<o2::framework::ConfigParamSpec> options{
-    {"input-type", o2::framework::VariantType::String, "hits", {"hits, digits, raw, clusters"}},
-    {"output-type", o2::framework::VariantType::String, "digits", {"digits, raw, clusters, cells"}},
-    {"enable-digits-printer", o2::framework::VariantType::Bool, false, {"enable digits printer component"}},
+    {"input-type", o2::framework::VariantType::String, "digits", {"hits, digits, raw, clusters"}},
+    {"output-type", o2::framework::VariantType::String, "cells", {"digits, raw, clusters, cells"}},
     {"disable-mc", o2::framework::VariantType::Bool, false, {"disable sending of MC information"}},
     {"disable-root-input", o2::framework::VariantType::Bool, false, {"disable root-files input reader"}},
     {"disable-root-output", o2::framework::VariantType::Bool, false, {"disable root-files output writer"}},
-  };
+    {"configKeyValues", o2::framework::VariantType::String, "", {"Semicolon separated key=value strings ..."}}};
   std::swap(workflowOptions, options);
 }
 
@@ -54,11 +54,13 @@ void customize(std::vector<o2::framework::ConfigParamSpec>& workflowOptions)
 o2::framework::WorkflowSpec defineDataProcessing(o2::framework::ConfigContext const& cfgc)
 {
   //
+  // Update the (declared) parameters if changed from the command line
+  o2::conf::ConfigurableParam::updateFromString(cfgc.options().get<std::string>("configKeyValues"));
+
   return o2::phos::reco_workflow::getWorkflow(cfgc.options().get<bool>("disable-root-input"),
                                               cfgc.options().get<bool>("disable-root-output"),
-                                              !cfgc.options().get<bool>("disable-mc"),           //
-                                              cfgc.options().get<bool>("enable-digits-printer"), //
-                                              cfgc.options().get<std::string>("input-type"),     //
-                                              cfgc.options().get<std::string>("output-type")     //
+                                              !cfgc.options().get<bool>("disable-mc"),       //
+                                              cfgc.options().get<std::string>("input-type"), //
+                                              cfgc.options().get<std::string>("output-type") //
   );
 }


### PR DESCRIPTION
Hi @peressounko 

Due to the inconsistent default options both phos and cpv workflow produce errors when run w/o any arguments or help asked, i.e. ``o2-phos-reco-workflow -h``.  In fact, do you need "hits" in these options at all?

Could you please merge this PR? Apart from fixing the option, it 
1) adds ``configKeyValues`` option and ``o2::conf::ConfigurableParam::updateFromString(configcontext.options().get<std::string>("configKeyValues"));`` to both workflows  to allow passing both global (like the TF length etc.) and local settings.
2) With your updates, the ``enable-digits-printer`` became obsolete, I've removed it.

Cheers,
 Ruben